### PR TITLE
Keep extension working after display settings changes

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -16,15 +16,22 @@
  **/
 
 const Main = imports.ui.main;
+let monitorsChangedEvent = null;
 
-function enable() {
+function hideIndicator() {
     let indicator = Main.panel.statusArea['activities'];
     if(indicator != null) {
         indicator.container.hide();
     }
 }
 
+function enable() {
+    monitorsChangedEvent = Main.layoutManager.connect('monitors-changed', hideIndicator);
+    hideIndicator();
+}
+
 function disable() {
+    Main.layoutManager.disconnect(monitorsChangedEvent);
     let indicator = Main.panel.statusArea['activities'];
     if(indicator != null) {
         indicator.container.show();


### PR DESCRIPTION
Every time a display setting has changed, this extension stop works. Tested on Gnome 3.36 (Ubuntu 20.04).