### PR TITLE
Add support for GNOME 47 to metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Hides the Activities button from the status bar (the hot corner and keyboard shortcut keeps working). To disable top left hot corner use 'No Topleft Hot Corner' extension \u2014 https://extensions.gnome.org/extension/118/no-topleft-hot-corner/ .",
   "name": "Hide Activities Button",
-  "shell-version": ["45", "46"],
+  "shell-version": ["45", "46", "47"],
   "url": "https://github.com/zeten30/HideActivities",
   "uuid": "Hide_Activities@shay.shayel.org",
   "version": 45


### PR DESCRIPTION
Working on GNOME 47, no changes required