### PR TITLE
Remove deprecated extension from description

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Hides the Activities button from the status bar (the hot corner and keyboard shortcut keeps working). To disable top left hot corner use 'No Topleft Hot Corner' extension \u2014 https://extensions.gnome.org/extension/118/no-topleft-hot-corner/ .",
+  "description": "Hides the Activities button from the status bar (the hot corner and keyboard shortcut keeps working).",
   "name": "Hide Activities Button",
   "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/zeten30/HideActivities",


### PR DESCRIPTION
The hot corner can be turned off from settings now so the linked extension has been deprecated