### PR TITLE
Rework build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: release
+
 release:
 	gnome-extensions pack --force \
 	  --extra-source=LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
 release:
 	gnome-extensions pack --force \
-	  --extra-source=LICENSE \
-	  --extra-source=README.md
+	  --extra-source=LICENSE

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,19 @@
-.PHONY: release
+UUID := Hide_Activities@shay.shayel.org
+BUILD_DIR ?= build
+BUNDLE_PATH := "$(BUILD_DIR)/$(UUID).shell-extension.zip"
 
-release:
-	gnome-extensions pack --force \
-	  --extra-source=LICENSE
+.PHONY: release build package clean
+
+release: build
+
+build: clean
+	@mkdir -p $(BUILD_DIR)
+	$(MAKE) package
+
+package:
+	@gnome-extensions pack --force \
+	  --extra-source=LICENSE \
+	  -o ./$(BUILD_DIR)/
+
+clean:
+	@rm -rfv $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
 release:
-	rm -rf Hide_Activities@zeten30.gmail.com.zip
-	zip -j Hide_Activities@zeten30.gmail.com.zip extension.js LICENSE metadata.json README.md stylesheet.css
+	gnome-extensions pack --force \
+	  --extra-source=LICENSE \
+	  --extra-source=README.md


### PR DESCRIPTION
 - Use the `gnome-extensions` tool to build the extension bundle
   - This keeps it inline with upstream's expectations
 - Correct the bundle's filename to match the UUID
   - This might be a requirement upstream now, they've rolled out a new tool for checking extensions and they're more strict on naming
 - Don't include `README.md` in the bundle
   - None of the information in it applied to the downloaded bundle, so this keeps the filesize smaller
 - Add `Makefile` recipes to `.PHONY`
 - Clean up build system log output
 - Place the built extension in `build/` by default, it can be overridden with the `BUILD_DIR` environment variable
 - Add `clean`, `build` and `package` recipes
   - `clean` is useful to clean up
   - `build` and `package` aren't strictly necessary, but they break the rules up and bring this in line with the other extensions I maintain