### PR TITLE
Add extension build, check and upload workflow

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,36 @@
+# This workflow will build the extension and upload an artifact
+name: Build, check and upload extension
+
+on:
+  push:
+    branches: '**'
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-slim
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+
+    steps:
+    - uses: actions/checkout@v7
+    - name: Install build dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends make gettext gnome-shell
+
+    - name: Build the extension bundle
+      run: |
+        make build
+
+    - name: Run Shexli on the extension
+      uses: stuarthayhurst/shexli-github-action@v1
+      with:
+        path: build/Hide_Activities@shay.shayel.org.shell-extension.zip
+        ignored-checks: 'EGO-M-004'
+
+    - uses: actions/upload-artifact@v7
+      with:
+        name: Hide_Activities@shay.shayel.org.shell-extension.zip
+        path: build/Hide_Activities@shay.shayel.org.shell-extension.zip
+        archive: false


### PR DESCRIPTION
 - Copied from https://github.com/stuarthayhurst/alphabetical-grid-extension/blob/master/.github/workflows/build-extension.yml
 - Builds the extension bundle, runs it through Shexli and then uploads it
   - Shexli can process the source directory, but if we build the extension first it'll only warn about issues relevant to the distributed bundle, instead of anything going on with the source (such as translations and extra files)
   - Uploading it is useful for testing or users that want the latest build without building it themselves
     - `archive: false` avoids it being doubly compressed
   - The ignored check is to ignore the metadata version errors
   - It's configured to allow warnings (since there are some bugs ones sometimes), and fail on errors
     - Warnings and errors are both logged anyway
 - Also contains a line to avoid pull requests from the upstream repository (yours) running the workflow twice, once for commit and once for pull request

If you want you can use `ubuntu-latest` instead of `ubuntu-slim`
 - `ubuntu-latest` gets 4 cores instead of 1, but this only helps with installing the build dependencies
 - Overall `ubuntu-latest` results in higher actions minutes usage, but this shouldn't really be an issue unless you're running other huge pipelines elsewhere
   - I used `ubuntu-slim` for mine to leave the minutes usage free for some of my other projects that were drinking through my free allowance, then just left it the same here when I copied it